### PR TITLE
Speed up GUID generation and expose file_formats to users of the library

### DIFF
--- a/gnewcash/__init__.py
+++ b/gnewcash/__init__.py
@@ -4,6 +4,7 @@ Python package used to read, write, and interact with GnuCash file data.
 # flake8: noqa
 from .account import *
 from .commodity import *
+from .file_formats import *
 from .gnucash_file import *
 from .guid_object import *
 from .slot import *

--- a/gnewcash/guid_object.py
+++ b/gnewcash/guid_object.py
@@ -5,14 +5,14 @@ Module containing classes that manage GUID objects.
    :synopsis:
 .. moduleauthor: Paul Bromwell Jr.
 """
-from typing import List
+from typing import Set
 import uuid
 
 
 class GuidObject:
     """Class used to generate unique GUIDs for various GNewCash objects."""
 
-    used_guids: List[str] = []
+    used_guids: Set[str] = set()
 
     def __init__(self) -> None:
         super(GuidObject, self).__init__()
@@ -36,5 +36,5 @@ class GuidObject:
             random_uuid: uuid.UUID = uuid.uuid4()
             new_guid: str = str(random_uuid).replace('-', '').lower()
             if new_guid not in GuidObject.used_guids:
-                GuidObject.used_guids.append(new_guid)
+                GuidObject.used_guids.add(new_guid)
                 return new_guid

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from setuptools import setup
+from setuptools import find_packages, setup
 
 
 def read(file_name):
@@ -12,7 +12,7 @@ setup(
     description='Python Library for reading, interacting with, and writing GnuCash files',
     author='Paul Bromwell Jr.',
     author_email='pbromwelljr@gmail.com',
-    packages=['gnewcash'],
+    packages=find_packages(),
     license='MIT',
     keywords='gnucash finance finances cash personal banking',
     url='https://github.com/pbromwelljr/gnewcash',


### PR DESCRIPTION
Thanks for this library! I've been using it for a year and half and it's working quite well for me.

This PR addresses a couple things, and I'm happy to split it into two PRs if you prefer:
* Keep track of used GUIDs in a set rather than a list, so that membership checks are more efficient. I saw a reduction from ~15.5s to ~0.3s spent in the `get_guid` function when loading ~40k transactions with this change. I didn't see any other usages of `used_guids` that needed it to be list, so this seems like a strict improvement.
* Import everything from `gnewcash/file_formats` in `gnewcash/__init__.py` so that they can be used with `GnuCashFile.read_file()`, which requires a `file_format` argument since 1.0.2. This had been blocking me from updating beyond 1.0.1. And, now that we're including a subpackage, use `find_packages()` from setuptools in `setup.py`, which is smart about those kinds of things.

The only new warning from the commands listed in the contribution docs is:

```
$ mypy gnewcash
Warning: unused section(s) in mypy.ini: [mypy-xml.dom]
```

I suppose that section in `mypy.ini` can come out now that the XML-related directories are imported? Not positive, though.